### PR TITLE
Add meeting calendar link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@ This repo serves to provide a structure for activity, discussions and decisions 
 
 ***
 
-## Meeting Notes:
+## Meeting Links:
+
+The calendar for upcoming meetings can be found [here](https://zoom-lfx.platform.linuxfoundation.org/meetings/hiero?view=week)
+
+## Meeting Minutes:
 
 The minutes of the TSC meetings can be found [here](https://github.com/hiero-ledger/tsc/tree/main/minutes)
 


### PR DESCRIPTION
By adding the LF meeting zoom calendar link to the README of this repo, it will be easier for folks to get connected.