### PR TITLE
Add LF Indiividual Dashboard link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,12 @@ This repo serves to provide a structure for activity, discussions and decisions 
 
 The calendar for upcoming meetings can be found [here](https://zoom-lfx.platform.linuxfoundation.org/meetings/hiero?view=week)
 
-## Meeting Minutes:
+## Meeting Summaries & Secordings:
 
-The minutes of the TSC meetings can be found [here](https://github.com/hiero-ledger/tsc/tree/main/minutes)
+The summaries, minutes and recordings of the past Hiero TSC meetings can be found [here in the repository](https://github.com/hiero-ledger/tsc/tree/main/minutes). Additionally, you can login to your Linux Foundation [Individual Dashboard](https://openprofile.dev/) to view recordings and transcripts.
 
 ## Discussion Area:
 GitHub discussions - [wiki](https://github.com/orgs/hiero-ledger/discussions)
 
 ## TSC Issues:
 Issues [Home](https://github.com/hiero-ledger/tsc/issues)
-
-


### PR DESCRIPTION
this PR updates the README.md file to include a link to the Linux Foundation Individual Dashboard, letting users know they can access past TSC recordings.