### PR TITLE
TSC meeting summary for April 8th 2025

### DIFF
--- a/minutes/2025-04-08.md
+++ b/minutes/2025-04-08.md
@@ -1,14 +1,36 @@
-## TSC Attendees
+# Hiero Technical Steering Committee Meeting
 
-## Guests
+**TL;DR:** Hiero’s TSC reviewed updates on project transitions and upcoming elections. A major topic was a proposal to bring the Hashgraph Online Standards SDK into the Hiero project. The TSC welcomed the idea but postponed a vote to allow time for additional governance and naming discussions.
 
+## Details
 
-## Code of Conduct
+**Organization:** Hiero Technical Steering Committee  
+**Date:** April 8, 2025  
+**Time:** 10:00 AM ET  
+**Recording:** [Zoom Recording](https://zoom.us/rec/share/4HhJP-7kBaA4YUXFSMOl5TnKGA2z_YX8zqH9dcxnUDIN7zGIkcbo6A0q12sXY6uc.OfQ5KblzwflrJFcH)
 
-As in every meeting we start with a short notice of the [antitrust policy of Linux Foundation](https://www.linuxfoundation.org/legal/antitrust-policy)
-and an introduction of our [Code of Conduct](https://www.lfdecentralizedtrust.org/code-of-conduct).
+## Attendees
 
-<img width="945" alt="Code of Conduct" src="https://github.com/user-attachments/assets/3a187bc9-65ae-461e-bb46-7ce0db8e32cf">
+**TSC Members**
+- Alex Popowycz
+- Leemon Baird
+- Richard Bair
+- Hendrik Ebbers
+
+**Guests**
+- Brandon Davenport
+- Michael Kantor
+- Andrew Brandt
+- Diane Mueller
+- Jessica Gonzalez
+- Keith Kowal
+- Louis Fourie
+- Pavel Borsov
+- Rob Walworth
+- Robert Linton
+- Roger Barker
+- Sophie Bulloch
+- Sumabala Nair
 
 ## Agenda
 
@@ -19,4 +41,62 @@ and an introduction of our [Code of Conduct](https://www.lfdecentralizedtrust.or
 - Presentation of hashgraph-online/standards-sdk as possible Hiero project (https://github.com/hiero-ledger/tsc/issues/109)
 - Any other business (AOB)
 
-## Minutes
+## Meeting Summary
+
+- **Approval of Previous Minutes**  
+  Multiple pull requests are pending approval, including one from January. TSC members are encouraged to review and merge.
+
+- **Project Transition Updates**  
+  All Hedera-originated projects except for "Solo" have been successfully transferred. Solo’s transfer is targeted within the next 1–2 weeks, per Andrew Brandt.
+
+- **Community Project Onboarding**  
+  Several community projects have been onboarded, and more proposals are in queue. The TSC continues to review new project proposals weekly.
+
+- **Election Process for New TSC Seats**  
+  Two new seats will be elected in May:
+  - **Contributor Seat**: For those who have contributed merged code.
+  - **End User Seat**: For builders using Hiero tools, e.g., via the Adopters list.
+  Nominations are open, and more participation is encouraged.
+
+- **Promotional Clip Suggestion**  
+  Richard Bair suggested clipping and sharing the election pitch on social platforms to raise awareness.
+
+- **Project Proposal: Hashgraph Online Standards SDK**  
+  Michael Kantor presented the SDK and proposed onboarding into Hiero.
+  - SDK encapsulates open standards into an easy-to-use JavaScript library.
+  - Built by a consortium of retail orgs (e.g., HashPack, Badge, HGraph).
+  - Long-term goal: add multi-language support (e.g., Python, Java).
+  - Current SDK and standards governance is handled via Hashgraph Online DAO using tokens and on-chain voting in the Marshall Islands.
+
+- **Discussion: Governance and Integration**  
+  - Richard, Hendrik, and others raised concerns about the separation of standards governance and project code maintenance if it enters Hiero.
+  - Keith Kowal and others highlighted various points as to why HashGraph Online SDK would be a good addition to Hiero, offering additional perspectives.
+  - Suggestion to clarify the role of application-layer standards and possibly rework or sunset the application HIP process.
+  - Agreement that the SDK aligns with Hiro’s mission and could serve community needs, but integration needs governance clarity.
+  - Concerns were raised around potential naming confusion (e.g., “standards SDK”) if brought under Hiero.
+
+- **Next Steps**  
+  - Vote on onboarding postponed due to lack of quorum and need for further discussion.
+  - TSC to revisit SDK onboarding and naming decision in next week’s meeting.
+
+## Presentations
+
+**Standards SDK by Hashgraph Online**  
+Presenter: Michael Kantor  
+- Overview of consortium, current standards, SDK implementation, and usage.
+- Described real-world traction (28M transactions) and ecosystem adoption.
+- Responded to technical and governance questions from TSC members.
+
+## Action Items
+
+| Action | Owner | Due Date |
+|-------|-------|----------|
+| Review January meeting minutes PR | TSC | Before next meeting |
+| Share election nomination clip with marketing | Jessica Gonzalez | ASAP |
+| Finalize governance discussion for SDK integration | TSC | April 15 |
+| Decide on naming for SDK under Hiero repo | TSC | April 15 |
+| Review new proposal linked by Hendrik for next week | TSC Members | Before next TSC call |
+
+---
+
+Prepared by: Brandon Davenport, Dir of Comms, Hgraph


### PR DESCRIPTION
this PR updates the .md file for the April 8th 2025 Hiero Technical Steering Committee meeting.