### PR TITLE
Add minutes for TSC meeting on November 4, 2025

### DIFF
--- a/minutes/2025-11-04.md
+++ b/minutes/2025-11-04.md
@@ -1,20 +1,106 @@
+# Hiero Technical Steering Committee Meeting
+
+**TL;DR:** The TSC approved **HIP-1299** (7–1). The committee discussed adopting **X402 “Payment Required”** patterns on Hedera/Hiero, aligned on exploring an open-source facilitator template, and assigned outreach to the X402 group. Prior meeting minutes remain pending final review/approval.
+
+---
+
+## Details
+
+**Organization:** Hiero  
+**Date:** November 4, 2025  
+**Time:** 10:00 AM ET  
+**Recording:** https://zoom.us/rec/share/MeYfn4buBObmWRbgWB2gbiLunay_vhhDaK4leR613bFitpj64K-cT_wM8DHvINHd.esUG5jd1bsv_NXdd
+
+---
+
 ## TSC Attendees
+
+- Hendrik Ebbers  
+- Richard Bair  
+- Stoyan Panayotov  
+- Alexander Popowycz  
+- Michael Kantor  
+- Milan Wiercx van Rhijn  
+- Brandon Davenport  
+- Georgi Lazarov
+
+## Guests
+
+- Nana Essilfie-Conduah
+- Pavel Borisov
+- Tayebwa Noah
+- Mark Blackman
+- Amanda Clark
+- Andrew Brandt
+- Angelina Ceppaluni
+- Diane Mueller
+- Jessica Gonzalez
+- Jessie Ssebuliba
+- Joseph Sinclair
+- Keith Kowal
+- May Chan
+- Michael Garber
+
+---
+
+## Agenda Items
+
+- Approve previous minutes
+- HIPs ([Project board](https://github.com/orgs/hiero-ledger/projects/31/views/1?sortedBy%5Bdirection%5D=asc&sortedBy%5BcolumnId%5D=Status))
+- X402 project for Hiero (Presenter: Stoyan Panayotov)
+- Any other business (AOB)
 
 ## Guests
 
 As every Hiero meeting the TSC meeting is a public meeting and everybody can attend it.
-You can find all the information about the TSC meetings and all other Hiero meetings in our [public calender](https://zoom-lfx.platform.linuxfoundation.org/meetings/hiero?view=week).
+You can find all the information about the TSC meetings and all other Hiero meetings in our [public calender](https://zoom-lfx.platform.linuxfoundation.org/meetings/hiero).
 
 ## Code of Conduct
 
-As in every meeting we start with a short notice of the [antitrust policy of Linux Foundation](https://www.linuxfoundation.org/legal/antitrust-policy)
-and an introduction of our [Code of Conduct](https://www.lfdecentralizedtrust.org/code-of-conduct).
+As in every meeting we start with a short notice of the [antitrust policy of Linux Foundation](https://www.linuxfoundation.org/legal/antitrust-policy) and an introduction of our [Code of Conduct](https://www.lfdecentralizedtrust.org/code-of-conduct).
 
-<img width="945" alt="Code of Conduct" src="https://github.com/user-attachments/assets/3a187bc9-65ae-461e-bb46-7ce0db8e32cf">
+---
 
-## Agenda
+## Meeting Summary
 
-- Approve previous minutes
-- HIPs ([Project](https://github.com/orgs/hiero-ledger/projects/31/views/1?sortedBy%5Bdirection%5D=asc&sortedBy%5BcolumnId%5D=Status))
-- x402 project for Hiero (Stoyan)
-- Any other business (AOB)
+- **Prior minutes:** PRs for **Oct 21** and **Oct 28** meetings are open in the TSC repo and need final review/approval by members.
+- **HIPs:** The board was reviewed. The only item at “Ready to Vote” was **HIP-1299**.
+- **Vote – HIP-1299:** Conducted live (async vote was deferred). **Result: Approved 7–1.**
+- **X402 overview (Stoyan):**  
+  - X402 revives HTTP **402 Payment Required** for paid APIs; clients/agents receive a 402 with payment instructions, sign an **EIP-712** message, and the **facilitator** settles on-chain; access is then granted.  
+  - Opportunity for Hedera/Hiero to implement or interoperate (e.g., supporting HBAR and stablecoins) and to provide a simple, reusable facilitator template for developers.  
+  - Related/adjacent efforts to consider alongside X402: **Cloudflare “Deferred”** and **Circo “Batched”** standards.
+- **Discussion highlights:**  
+  - **Go-to-market & adoption:** Resource owners will want easy, chain-agnostic options; a **templated, clonable facilitator gateway** (with clear deploy guides, e.g., Cloudflare) could accelerate adoption.  
+  - **Ecosystem fit:** Hedera’s performance/fees seen as a strong technical match; encourage multi-chain support so users can pay from where they already hold funds.  
+  - **Standards participation:** Desire for Hiero/Hedera representation in the emerging X402 community to ensure inclusive design and compatibility.  
+  - **Implementations observed:** Hgraph and community collaborators have early facilitator work; MCP tooling from Hgraph enables LLM agents to interact with Hedera services—complementary to X402-style paid API access.
+
+- **AOB:** Reminder to monitor and participate in **hiero-ledger org discussions** on GitHub.
+
+---
+
+## Presentations
+
+**X402 “Payment Required” for paid APIs (Stoyan Panayotov)**  
+- Goal: Enable human/agent clients to pay for API calls using standard HTTP flows plus cryptographic signing, with an on-chain facilitator handling settlement.  
+- Flow: Client → resource server (402) → client signs → server → facilitator → on-chain settlement → access granted.  
+- Fit for Hiero/Hedera: Provide an **open-source facilitator template** supporting HBAR and stablecoins; consider discovery/multi-currency selection; align with agentic use cases and existing MCP tools.
+
+---
+
+## Key Decisions
+
+- **HIP-1299 approved (7–1).**  
+- **Direction:** Explore publishing an **open-source, templated X402 facilitator/gateway** under the Hiero org (no formal vote taken; broad support expressed).  
+- **Standards engagement:** Proceed with outreach to the X402 group to understand membership/participation paths.
+
+**Action Items**
+- **All TSC members:** Review and approve the **Oct 21** and **Oct 28** meeting minutes PRs in the TSC repo.  
+- **Hendrik & Jessica:** Document and share the **asynchronous voting process** so future HIP votes can run async when needed.  
+- **Michael Kantor:** **Reach out** to the X402 organization/foundation and **report back** on how Hiero/Hedera can participate.  
+- **(Optional next step)** Stoyan and interested collaborators: Draft a brief comparing **X402**, **Deferred**, and **Batched** patterns to scope facilitator requirements (not assigned by vote).
+
+---
+
+Prepared by: Brandon Davenport, Dir of Product, Hgraph


### PR DESCRIPTION
This PR adds the comprehensive minutes from the November 4, 2025 TSC meeting, including:
- Approval of HIP-1299 (7-1 vote)
- Discussion of X402 "Payment Required" patterns for Hedera/Hiero
- Action items for TSC members
- Full attendee list and meeting summary