### PR TITLE
Add minutes for TSC meeting on 2025-11-11

### DIFF
--- a/minutes/2025-11-11.md
+++ b/minutes/2025-11-11.md
@@ -1,19 +1,113 @@
+# Hiero Technical Steering Committee Meeting
+
+**TL;DR:** No votes this week. The TSC aligned on enabling **asynchronous voting with GitVote**, agreed to **trial GitHub Wikis** for community meeting agendas, and discussed a new **Identity Collaboration Hub** proposal to consolidate identity efforts. Hacktoberfest produced ~100 good-first-issue contributions across multiple repos.
+
+---
+
+## Details
+
+**Organization:** Hiero  
+**Date:** November 11, 2025  
+**Time:** 10:00 AM ET  
+**Recording:** https://zoom.us/rec/share/3c015sI1z8P7f-kZyM43n555o5onC30bV9aE8-_xbyE1MzS6ZA6BMOvrcUDr7XTa.I9-tiifTGLSaenBH
+
+---
+
 ## TSC Attendees
+
+- Hendrik Ebbers
+- Michael Kantor
+- Stoyan Panayotov
+- Georgi Lazarov
 
 ## Guests
 
-As every Hiero meeting the TSC meeting is a public meeting and everybody can attend it.
-You can find all the information about the TSC meetings and all other Hiero meetings in our [public calender](https://zoom-lfx.platform.linuxfoundation.org/meetings/hiero?view=week).
+- Jessica Gonzalez
+- Michael Garber
+- May Chan
+- Joseph Sinclair
+- Diane Mueller
+- Keith Kowal
+- Alexander Shenshin
+- Andrew Brandt.)
+- Roger Barker
+- Sophie Bulloch
+
+---
+
+## Agenda Items
+
+- Approve previous minutes (still pending merge/approval)
+- HIPs — status review via the HIP Tracker board (no items requiring a TSC vote this week).
+- Any other business (AOB)
+
+Additional topics raised during AOB:
+- Enable GitHub-based **asynchronous voting** (GitVote) for HIP PRs and similar decisions.
+- **Identity Collaboration Hub** proposal (reframing from “Identity Workbench”).
+- **Governance repo** meeting agendas workflow — trial **GitHub Wikis** to reduce PR overhead.
+- **Hacktoberfest outcomes** and **good-first-issue** best practices.
+- Contributor **training** needs (DCO/sign-off, repo workflows, Hedera/Hiero domain basics).
+
+## Guests
+
+As every Hiero meeting the TSC meeting is a public meeting and everybody can attend it.  
+You can find all the information about the TSC meetings and all other Hiero meetings in our [public calender](https://zoom-lfx.platform.linuxfoundation.org/meetings/hiero).
 
 ## Code of Conduct
 
-As in every meeting we start with a short notice of the [antitrust policy of Linux Foundation](https://www.linuxfoundation.org/legal/antitrust-policy)
-and an introduction of our [Code of Conduct](https://www.lfdecentralizedtrust.org/code-of-conduct).
+As in every meeting we start with a short notice of the [antitrust policy of Linux Foundation](https://www.linuxfoundation.org/legal/antitrust-policy) and an introduction of our [Code of Conduct](https://www.lfdecentralizedtrust.org/code-of-conduct).
 
-<img width="945" alt="Code of Conduct" src="https://github.com/user-attachments/assets/3a187bc9-65ae-461e-bb46-7ce0db8e32cf">
+---
 
-## Agenda
+## Meeting Summary
 
-- Approve previous minutes
-- HIPs ([Project](https://github.com/orgs/hiero-ledger/projects/31/views/1?sortedBy%5Bdirection%5D=asc&sortedBy%5BcolumnId%5D=Status))
-- Any other business (AOB)
+- **Minutes:** Prior week’s minutes noted as not yet approved/merged; to be handled in the coming days.
+- **HIPs:** Several HIPs are in creation; **no votes required** this week. Community was encouraged to pre-review the HIP referenced on the call ahead of its TSC presentation.
+- **Async voting with GitVote:**  
+  - Jessica added a GitVote configuration enabling **TSC team voting** on PRs with **3-day duration** and **50% pass threshold**; multiple profiles can be defined per team.  
+  - Voting happens via reactions (👍 / 👎 / 👀) and is restricted to allowed voters defined in `.gitvote.yml`.
+  - Jessica will **walk through GitVote** usage in next Thursday’s community call (recorded).
+- **Identity Collaboration Hub:**  
+  - Aim: a **single, discoverable hub** for identity work (docs, designs, some code, starter tools) while **keeping SDK repos separate** (due to dependency usage).  
+  - Naming to align with “Hub” used elsewhere (e.g., SDK Hub) for consistency.  
+  - Keith will **withdraw and rewrite** the proposal to “Identity Collaboration Hub” (with “Workbench” as a sub-tool) and bring it back next week for a vote.
+- **Community meetings & agendas:**  
+  - Two community calls Thursday (Identity; Data Output/Mirror Node).  
+  - A **project-meetings** area exists in the governance repo, but PR-based edits felt heavy for agendas.  
+  - Group agreed to **trial GitHub Wikis** in the governance repo, with edit rights restricted to teams with write access; maintain **least-privilege** access.
+- **Hacktoberfest outcomes:**  
+  - ~**100 “good first issues”** solved (≈92 merged + 7 in review at the time discussed).  
+  - Multiple repeat contributors; at least one new **committer** emerged from October contributions (Python SDK).  
+  - Contributions spanned **Python SDK**, **Consensus Node**, **Mirror Node**, and **website**.  
+  - **What worked:** clear issue templates (description, proposed solution, checklist), example code, links to related items, and—surprisingly—**emojis** improved uptake.  
+  - A **template** for good-first-issues lives in the org’s `.github` repo and will be **synced** across repos.
+- **Training needs:**  
+  - Plan to create **short video guides** (creating PRs, DCO/sign-off, how to review/create good-first-issues).  
+  - For newcomers, provide **domain primers** (transactions vs. consensus files, what to generate, how to run examples) to lower contribution friction.
+
+---
+
+## Presentations (optional)
+
+- **Hacktoberfest Results & Learnings** — overview deck by Hendrik Ebbers summarizing contribution metrics, examples of successful good-first-issues, and proposed improvements to templates and training.
+
+---
+
+## Key Decisions
+
+- **Trial GitHub Wikis** for community meeting agendas in the governance repo (restricted editing to teams with write access).  
+- **Proceed with GitVote** configuration for **asynchronous TSC votes** on eligible PRs (e.g., HIPs) to avoid delays when quorum is not available.
+- **Reframe identity proposal** to **Identity Collaboration Hub** (keep SDKs in their own repos; “Workbench” can live under the Hub).
+
+**Action Items**
+- **Hendrik/TSC** — Review and merge **previous minutes**.
+- **All TSC** — **Pre-review the HIP referenced on the call**
+- **Jessica** — Deliver **GitVote walkthrough** during next Thursday’s community call (recorded).  
+- **Keith (with Diane)** — **Rewrite** Identity Collaboration Hub proposal and resubmit for next week’s TSC discussion/vote.  
+- **Jessica / Roger / Andrew** — **Enable & configure GitHub Wiki** on the governance repo; verify edit permissions for relevant teams.  
+- **Roger** — Maintain the **good-first-issue template** in the org-level `.github` repo and **sync** to sub-repos.  
+- **Hendrik + volunteers (incl. Jad, Sophie, others)** — Draft **short training videos** and **domain primers** to support new contributors.
+
+---
+
+Prepared by: Brandon Davenport, Dir of Product, Hgraph


### PR DESCRIPTION
This PR adds the comprehensive minutes from the November 11, 2025 TSC meeting, including:
- Discussion of asynchronous voting with GitVote
- Identity Collaboration Hub proposal
- GitHub Wikis trial for community meeting agendas
- Hacktoberfest outcomes (~100 good-first-issue contributions)
- Action items for TSC members