### PR TITLE
Add minutes for TSC meeting on December 2, 2025

### DIFF
--- a/minutes/2025-12-02.md
+++ b/minutes/2025-12-02.md
@@ -1,0 +1,23 @@
+## TSC Attendees
+
+## Guests
+
+As every Hiero meeting the TSC meeting is a public meeting and everybody can attend it.
+You can find all the information about the TSC meetings and all other Hiero meetings in our [public calender](https://zoom-lfx.platform.linuxfoundation.org/meetings/hiero?view=week).
+
+## Code of Conduct
+
+As in every meeting we start with a short notice of the [antitrust policy of Linux Foundation](https://www.linuxfoundation.org/legal/antitrust-policy)
+and an introduction of our [Code of Conduct](https://www.lfdecentralizedtrust.org/code-of-conduct).
+
+<img width="945" alt="Code of Conduct" src="https://github.com/user-attachments/assets/3a187bc9-65ae-461e-bb46-7ce0db8e32cf">
+
+## Agenda
+
+- Approve previous minutes
+- Any Updates/Events from Communities or members?
+- HIPs ([Project](https://github.com/orgs/hiero-ledger/projects/31/views/1?sortedBy%5Bdirection%5D=asc&sortedBy%5BcolumnId%5D=Status))
+- Project proposals voting: [Hiero Contracts Repository](https://github.com/hiero-ledger/tsc/issues/248) and [Hiero Ethereum Client Spec](https://github.com/hiero-ledger/tsc/issues/249)
+- Project proposals voting: [Identity Collaboration Hub](https://github.com/hiero-ledger/tsc/issues/263)
+- Project proposals voting: [hiero-hol-hcs-specs](https://github.com/hiero-ledger/tsc/issues/261)
+- Any other business (AOB)


### PR DESCRIPTION
This pull request adds the initial draft for the minutes of the TSC meeting scheduled for December 2, 2025. The new document provides structure for attendees, guests, code of conduct, and the meeting agenda.