### PR TITLE
Add minutes for TSC meeting on 2025-11-18

### DIFF
--- a/minutes/2025-04-22.md
+++ b/minutes/2025-04-22.md
@@ -1,16 +1,47 @@
+# Hiero Technical Steering Committee (TSC) Meeting
+
+**TL;DR:** The Hiero TSC discussed several major milestones, including the successful transition of Hedera projects to Hiero, the onboarding of two new projects, election deadlines for new TSC seats, a security policy update, and governance documentation for maintainers and committers. Important progress was made on voting procedures, security guidelines, and project governance, but further discussion is needed around SDK application HIPs.
+
+## Details
+
+**Organization:** Hiero Project, Linux Foundation Decentralized Trust  
+**Date:** April 22, 2025  
+**Time:** 10:00 AM ET  
+**Recording:** [Zoom Recording](https://zoom.us/rec/share/2dP6fdClTpBSWAMu1qKw9aJ8ndZEuRnmyVtHevbyhuxCj0_0lvAvqrxfOcoD5dLZ.yCN05zeEH9lWdtUl)
+
 ## TSC Attendees
+
+- Leemon Baird
+- Hendrik Ebbers
+- Alex Popowycz
+- Richard Bair
 
 ## Guests
 
+- Robert Linton
+- Roger Barker
+- Sophie Bulloch
+- Weijia Zhang
+- Brandon Davenport
+- Diane Mueller
+- Jessica Gonzalez
+- Andrew Brandt
+- Keith Kowal
+- Krystal I
+- Mark Blackman
+- May Chan
+- Michael Kantor
+- Michiel (no last name shown)
+- Milan Wiercx van Rhijn
+- Pavel Borisov
+- Rob Walworth
+- Weijia Zhang
 
 ## Code of Conduct
 
-As in every meeting we start with a short notice of the [antitrust policy of Linux Foundation](https://www.linuxfoundation.org/legal/antitrust-policy)
-and an introduction of our [Code of Conduct](https://www.lfdecentralizedtrust.org/code-of-conduct).
+As in every meeting we start with a short notice of the [antitrust policy of Linux Foundation](https://www.linuxfoundation.org/legal/antitrust-policy) and an introduction of our [Code of Conduct](https://www.lfdecentralizedtrust.org/code-of-conduct).
 
-<img width="945" alt="Code of Conduct" src="https://github.com/user-attachments/assets/3a187bc9-65ae-461e-bb46-7ce0db8e32cf">
-
-## Agenda
+## Agenda Items
 
 - Approve previous minutes 
 - Update on project transition (https://github.com/hiero-ledger/hiero/blob/main/transition.md & https://github.com/hiero-ledger/hiero/blob/main/community-transition.md)
@@ -23,4 +54,48 @@ and an introduction of our [Code of Conduct](https://www.lfdecentralizedtrust.or
 - Dual publishing for SDKs (under 2 com.hedera and org.hiero namespace) for a more easy migration
 - Any other business (AOB)
 
-## Minutes
+## Meeting Summary
+
+- **Previous Minutes Approval**: Some PRs pending additional approvals. Brandon will check PR 95.
+- **Project Transition**: Transition of Hedera projects to Hiero completed successfully.
+- **New Project Onboarding**:
+  - **Hashgraph Online** and **Open Elements Hiero Enterprise Java** were approved to join Hiero (pending final repo naming adjustments).
+- **TSC Elections**:
+  - Deadline for nominations: April 30.
+  - Guides and videos are being published to assist new nominees.
+- **Blog Naming Issue**:
+  - Linux Foundation raised concerns about branding. Proposal to rename Hiero blog to "Maintainers' Corner" was discussed but opposed by Diane Mueller.
+  - Jessica will escalate the concern internally at LF for review.
+- **Security Policy**:
+  - New security guidelines were presented.
+  - Discussion about integrating Hiero projects into existing security processes (e.g., Immunefi for bug bounties).
+  - Plan to add security.md references across all project repositories.
+- **Groups and Roles Documentation**:
+  - New governance document for maintainers, committers, and contributors drafted.
+  - TSC members asked to review it before voting in next week’s meeting.
+- **HIPs for SDK Changes**:
+  - Ongoing discussion whether SDK changes should require Application HIPs.
+  - Agreement to continue discussions in next week's meeting.
+
+## Key Decisions
+
+- Approval to onboard two new projects:
+  - **Hashgraph Online** (under a new name, to be discussed).
+  - **Open Elements Hiero Enterprise Java**.
+- Agreement to continue current use of the blog as-is pending final decision from the LF.
+- Confirmed April 30 as the nomination deadline for TSC elections.
+
+## Action Items
+
+- **Brandon Davenport**: Review and finalize approval on PR 95.
+- **Jessica Gonzalez**:  
+  - Follow up with LF leadership regarding blog naming conventions.  
+  - Proceed with security policy implementation across Hiero projects.  
+  - Coordinate with Keith Kowal on security reporting alignment (Immunefi vs. LF bounty programs).
+- **All TSC Members**: Review the Groups and Roles governance PR before the next meeting.
+- **Michael Kantor**: Propose a new name for the "Standards SDK" repository.
+
+
+---
+
+Prepared by: Brandon Davenport, Dir of Comms, Hgraph

--- a/minutes/2025-11-18.md
+++ b/minutes/2025-11-18.md
@@ -1,16 +1,43 @@
+# Hiero Technical Steering Committee Meeting
+
+**TL;DR:** Previous minutes were confirmed; two new project proposals (Hiero Contracts repo and Hiero Ethereum Client Spec) were deferred to next week. Sophie Bulloch presented a strong Python SDK Hacktoberfest report (major contributor growth) and proposed training + automation to scale. Keith Kowal previewed an Identity Collaboration Hub concept to centralize identity docs/standards and lightweight code.
+
+---
+
+## Details
+
+**Organization:** Hiero  
+**Date:** November 18, 2025  
+**Time:** 10:00–11:01 ET  
+**Recording:** https://zoom.us/rec/share/B-Z9JnbPCYHPTLpDAT5lpi9CxrWMwOiFZ8wQbAbpKeV7D5C16GUfQ16YwEefbDjR.07n1geBaev8SNHq0
+
+---
+
 ## TSC Attendees
+
+- Brandon Davenport
+- Hendrik Ebbers
+- Alexander Popowycz
+- Michael Kantor
+- Milan Wiercx van Rhijn
+- Richard Bair
+- Stoyan Panayotov
 
 ## Guests
 
-As every Hiero meeting the TSC meeting is a public meeting and everybody can attend it.
-You can find all the information about the TSC meetings and all other Hiero meetings in our [public calender](https://zoom-lfx.platform.linuxfoundation.org/meetings/hiero?view=week).
+- Andrew Brandt
+- Angelina Ceppaluni
+- Diane Mueller
+- Jessica Gonzalez
+- Jessie Ssebuliba
+- Joseph Sinclair
+- Keith Kowal
+- Mark Blackman
+- Pavel Borisov
+- Roger Barker
+- Sophie Bulloch
 
-## Code of Conduct
-
-As in every meeting we start with a short notice of the [antitrust policy of Linux Foundation](https://www.linuxfoundation.org/legal/antitrust-policy)
-and an introduction of our [Code of Conduct](https://www.lfdecentralizedtrust.org/code-of-conduct).
-
-<img width="945" alt="Code of Conduct" src="https://github.com/user-attachments/assets/3a187bc9-65ae-461e-bb46-7ce0db8e32cf">
+---
 
 ## Agenda
 
@@ -20,3 +47,68 @@ and an introduction of our [Code of Conduct](https://www.lfdecentralizedtrust.or
 - Project proposals presentations: [Hiero Contracts Repository](https://github.com/hiero-ledger/tsc/issues/248) and [Hiero Ethereum Client Spec](https://github.com/hiero-ledger/tsc/issues/249)
 - Python SDK Hacktoberfest update
 - Any other business (AOB)
+
+## Guests
+
+As every Hiero meeting the TSC meeting is a public meeting and everybody can attend it.  
+You can find all the information about the TSC meetings and all other Hiero meetings in our [public calender](https://zoom-lfx.platform.linuxfoundation.org/meetings/hiero).
+
+## Code of Conduct
+
+As in every meeting we start with a short notice of the [antitrust policy of Linux Foundation](https://www.linuxfoundation.org/legal/antitrust-policy) and an introduction of our [Code of Conduct](https://www.lfdecentralizedtrust.org/code-of-conduct).
+
+---
+
+## Meeting Summary
+
+- **Minutes:** Prior minutes already merged; no objections raised.
+- **Community update:** Note that Milan attended **DevConnect**; encourage sharing such items earlier so the community can engage.
+- **HIPs:** No items for today. Expect incoming HIP activity (e.g., HIP-1313 and others targeting an upcoming release window) in the next meetings.
+- **Project proposals:**  
+  - **Hiero Contracts Repository** and **Hiero Ethereum Client Spec** were queued but the proposer wasn’t present; both moved to next week.  
+  - Michael Kantor’s separate proposal also moved to next week due to a Cloudflare-related incident limiting availability.
+- **Python SDK Hacktoberfest (presentation by Sophie Bulloch):**  
+  - Activity spiked (~**660%** growth); peak week rose from ~5 to **38** commits; **74** PRs merged in October, **~115** PRs merged over Oct→Nov; ~**40** new contributors, largely CS students/grads.  
+  - **What worked:** clear “good first issue” labeling; strong templates & examples; rapid, informative maintainer feedback.  
+  - **Gaps/needs:** contributors advancing beyond easy issues need **Hiero-specific internals training** (transactions, consensus, protobuf/serialization, client patterns). Maintainer time doesn’t scale linearly.  
+  - **Proposed remedies:**  
+    - Training: short video series / webinars (LFDT meetups possible), contributor-focused “SDK internals” materials; leverage LFDT Training & Certification once content exists.  
+    - **Automation:** bots for DCO/signing and failed-check guidance; CI to run example scripts; tooling to diff protobufs vs SDK surface to flag missing methods; generate “good first issue+” items.  
+  - **Follow-ons:** Hashgraph team suggested exploring **TCK coverage** extension to Python SDK as its importance grows for AI & data workloads.
+- **Identity Collaboration Hub (preview by Keith Kowal):**  
+  - Proposal for an **umbrella repo** to centralize identity architecture docs, standards (folding the previously approved Identity Standards repo), discussions, and **non-dependency demo/snippet code** (i.e., items that don’t warrant stand-alone projects or TSC approval).  
+  - Items that become dependencies (SDKs, libraries) remain separate and under normal governance. Some parts would still be governed via HIPS.  
+  - Discussion to continue next week; issue was posted during the meeting.
+
+---
+
+## Presentations
+
+- **Python SDK Hacktoberfest Retrospective — Sophie Bulloch**  
+  - Growth metrics, contributor personas, and repeatable playbook (issue labeling, docs, feedback loops).  
+  - Concrete automation prototypes (DCO/signing checks, CI nudges, example runners, protobuf-driven surface analysis).  
+  - Call for TSC/community support on training content and scaling maintainer capacity.
+
+---
+
+## Key Decisions
+
+- Prior minutes considered **approved** (already merged).
+- **Deferrals to next week:**  
+  - Hiero Contracts Repository proposal  
+  - Hiero Ethereum Client Spec proposal  
+  - Michael Kantor’s project proposal  
+  - Identity Collaboration Hub discussion & potential vote
+
+---
+
+## Action Items
+
+- **Hendrik**: Add deferred proposals (Contracts repo, Ethereum Client Spec, Michael’s proposal) and **Identity Collaboration Hub** to **next week’s** TSC agenda; include Jessica’s new wiki/agenda page.  
+- **Sophie**: Coordinate with LFDT (via Jessica/Diane) on options to present at Tech/TSC/Maintainer Days and to scope contributor-focused training content.  
+- **Hashgraph SDK leads**: Evaluate feasibility/timeline for expanding **TCK coverage** to the Python SDK.  
+- **All**: Review and comment on the Identity Collaboration Hub issue before next meeting.
+
+---
+
+Prepared by: Brandon Davenport, Dir of Product, Hgraph


### PR DESCRIPTION
This PR adds the comprehensive minutes from the November 18, 2025 TSC meeting, including:
- Project proposals deferred (Hiero Contracts Repository, Hiero Ethereum Client Spec)
- Python SDK Hacktoberfest retrospective by Sophie Bulloch (660% activity growth, 74 PRs merged, ~40 new contributors)
- Identity Collaboration Hub preview by Keith Kowal
- Action items for TSC members