### PR TITLE
Add minutes for TSC meeting on 2025-11-25

### DIFF
--- a/minutes/2025-04-22.md
+++ b/minutes/2025-04-22.md
@@ -1,16 +1,47 @@
+# Hiero Technical Steering Committee (TSC) Meeting
+
+**TL;DR:** The Hiero TSC discussed several major milestones, including the successful transition of Hedera projects to Hiero, the onboarding of two new projects, election deadlines for new TSC seats, a security policy update, and governance documentation for maintainers and committers. Important progress was made on voting procedures, security guidelines, and project governance, but further discussion is needed around SDK application HIPs.
+
+## Details
+
+**Organization:** Hiero Project, Linux Foundation Decentralized Trust  
+**Date:** April 22, 2025  
+**Time:** 10:00 AM ET  
+**Recording:** [Zoom Recording](https://zoom.us/rec/share/2dP6fdClTpBSWAMu1qKw9aJ8ndZEuRnmyVtHevbyhuxCj0_0lvAvqrxfOcoD5dLZ.yCN05zeEH9lWdtUl)
+
 ## TSC Attendees
+
+- Leemon Baird
+- Hendrik Ebbers
+- Alex Popowycz
+- Richard Bair
 
 ## Guests
 
+- Robert Linton
+- Roger Barker
+- Sophie Bulloch
+- Weijia Zhang
+- Brandon Davenport
+- Diane Mueller
+- Jessica Gonzalez
+- Andrew Brandt
+- Keith Kowal
+- Krystal I
+- Mark Blackman
+- May Chan
+- Michael Kantor
+- Michiel (no last name shown)
+- Milan Wiercx van Rhijn
+- Pavel Borisov
+- Rob Walworth
+- Weijia Zhang
 
 ## Code of Conduct
 
-As in every meeting we start with a short notice of the [antitrust policy of Linux Foundation](https://www.linuxfoundation.org/legal/antitrust-policy)
-and an introduction of our [Code of Conduct](https://www.lfdecentralizedtrust.org/code-of-conduct).
+As in every meeting we start with a short notice of the [antitrust policy of Linux Foundation](https://www.linuxfoundation.org/legal/antitrust-policy) and an introduction of our [Code of Conduct](https://www.lfdecentralizedtrust.org/code-of-conduct).
 
-<img width="945" alt="Code of Conduct" src="https://github.com/user-attachments/assets/3a187bc9-65ae-461e-bb46-7ce0db8e32cf">
-
-## Agenda
+## Agenda Items
 
 - Approve previous minutes 
 - Update on project transition (https://github.com/hiero-ledger/hiero/blob/main/transition.md & https://github.com/hiero-ledger/hiero/blob/main/community-transition.md)
@@ -23,4 +54,48 @@ and an introduction of our [Code of Conduct](https://www.lfdecentralizedtrust.or
 - Dual publishing for SDKs (under 2 com.hedera and org.hiero namespace) for a more easy migration
 - Any other business (AOB)
 
-## Minutes
+## Meeting Summary
+
+- **Previous Minutes Approval**: Some PRs pending additional approvals. Brandon will check PR 95.
+- **Project Transition**: Transition of Hedera projects to Hiero completed successfully.
+- **New Project Onboarding**:
+  - **Hashgraph Online** and **Open Elements Hiero Enterprise Java** were approved to join Hiero (pending final repo naming adjustments).
+- **TSC Elections**:
+  - Deadline for nominations: April 30.
+  - Guides and videos are being published to assist new nominees.
+- **Blog Naming Issue**:
+  - Linux Foundation raised concerns about branding. Proposal to rename Hiero blog to "Maintainers' Corner" was discussed but opposed by Diane Mueller.
+  - Jessica will escalate the concern internally at LF for review.
+- **Security Policy**:
+  - New security guidelines were presented.
+  - Discussion about integrating Hiero projects into existing security processes (e.g., Immunefi for bug bounties).
+  - Plan to add security.md references across all project repositories.
+- **Groups and Roles Documentation**:
+  - New governance document for maintainers, committers, and contributors drafted.
+  - TSC members asked to review it before voting in next week’s meeting.
+- **HIPs for SDK Changes**:
+  - Ongoing discussion whether SDK changes should require Application HIPs.
+  - Agreement to continue discussions in next week's meeting.
+
+## Key Decisions
+
+- Approval to onboard two new projects:
+  - **Hashgraph Online** (under a new name, to be discussed).
+  - **Open Elements Hiero Enterprise Java**.
+- Agreement to continue current use of the blog as-is pending final decision from the LF.
+- Confirmed April 30 as the nomination deadline for TSC elections.
+
+## Action Items
+
+- **Brandon Davenport**: Review and finalize approval on PR 95.
+- **Jessica Gonzalez**:  
+  - Follow up with LF leadership regarding blog naming conventions.  
+  - Proceed with security policy implementation across Hiero projects.  
+  - Coordinate with Keith Kowal on security reporting alignment (Immunefi vs. LF bounty programs).
+- **All TSC Members**: Review the Groups and Roles governance PR before the next meeting.
+- **Michael Kantor**: Propose a new name for the "Standards SDK" repository.
+
+
+---
+
+Prepared by: Brandon Davenport, Dir of Comms, Hgraph

--- a/minutes/2025-11-25.md
+++ b/minutes/2025-11-25.md
@@ -1,23 +1,105 @@
+# Hiero Technical Steering Committee Meeting
+
+**TL;DR:** TSC reviewed four new project proposals (Hiero Contracts, Hiero Ethereum Client Spec Tests, Identity Collaboration Hub, and HOL HCS Specs). With no quorum, voting is deferred to an async ballot or the next meeting. Community is asked to review HIP-1313 and proposal slide decks.
+
+---
+
+## Details
+
+**Organization:** Hiero  
+**Date:** November 25, 2025  
+**Time:** 10:00 AM ET  
+**Recording:** https://zoom.us/rec/share/idybVxJcDUTKtMyesnpNXsnTivlWdpwFde0esVCwwl189xNEegh61Kp9jceL_-2U.PQtS55TdQDapH9Gz
+
+---
+
 ## TSC Attendees
+
+- Hendrik Ebbers
+- Stoyan Panayotov
+- Michael Kantor
+- Alexander Popowycz
 
 ## Guests
 
-As every Hiero meeting the TSC meeting is a public meeting and everybody can attend it.
-You can find all the information about the TSC meetings and all other Hiero meetings in our [public calender](https://zoom-lfx.platform.linuxfoundation.org/meetings/hiero?view=week).
+- Keith Kowal
+- Diane Mueller
+- Fernando Paris
+- Will VJ
+- Ian (full name not stated)
+- Sophie Bulloch
+- Ashe (full name not stated)
+
+---
+
+## Agenda Items
+
+- Approve previous minutes  
+- Any updates/events from communities or members?  
+- HIPs — project board: [Hiero HIPs Project](https://github.com/orgs/hiero-ledger/projects/31/views/1?sortedBy%5Bdirection%5D=asc&sortedBy%5BcolumnId%5D=Status)  
+- Project proposals presentations:
+  - [Hiero Contracts Repository](https://github.com/hiero-ledger/tsc/issues/248)
+  - [Hiero Ethereum Client Spec (tests) Repository](https://github.com/hiero-ledger/tsc/issues/249)
+  - [Identity Collaboration Hub](https://github.com/hiero-ledger/tsc/issues/263)
+  - [hiero-hol-hcs-specs](https://github.com/hiero-ledger/tsc/issues/261)
+- Any other business (AOB)
+
+## Guests
+
+As every Hiero meeting the TSC meeting is a public meeting and everybody can attend it.  
+You can find all the information about the TSC meetings and all other Hiero meetings in our [public calender](https://zoom-lfx.platform.linuxfoundation.org/meetings/hiero).
 
 ## Code of Conduct
 
-As in every meeting we start with a short notice of the [antitrust policy of Linux Foundation](https://www.linuxfoundation.org/legal/antitrust-policy)
-and an introduction of our [Code of Conduct](https://www.lfdecentralizedtrust.org/code-of-conduct).
+As in every meeting we start with a short notice of the [antitrust policy of Linux Foundation](https://www.linuxfoundation.org/legal/antitrust-policy) and an introduction of our [Code of Conduct](https://www.lfdecentralizedtrust.org/code-of-conduct).
 
-<img width="945" alt="Code of Conduct" src="https://github.com/user-attachments/assets/3a187bc9-65ae-461e-bb46-7ce0db8e32cf">
+---
 
-## Agenda
+## Meeting Summary
 
-- Approve previous minutes
-- Any Updates/Events from Communities or members?
-- HIPs ([Project](https://github.com/orgs/hiero-ledger/projects/31/views/1?sortedBy%5Bdirection%5D=asc&sortedBy%5BcolumnId%5D=Status))
-- Project proposals presentations: [Hiero Contracts Repository](https://github.com/hiero-ledger/tsc/issues/248) and [Hiero Ethereum Client Spec](https://github.com/hiero-ledger/tsc/issues/249)
-- Project proposals presentations: [Identity Collaboration Hub](https://github.com/hiero-ledger/tsc/issues/263)
-- Project proposals presentations: [hiero-hol-hcs-specs](https://github.com/hiero-ledger/tsc/issues/261)
-- Any other business (AOB)
+- **Minutes approved:** Prior meeting minutes are merged and up to date.
+- **Community update:** Marketing meeting follows immediately after this call (see public calendar).
+- **HIPs:** No HIPs scheduled for review; **community asked to review HIP-1313** ahead of upcoming discussion.
+- **Proposal #1 — Hiero Contracts repository (presented by Fernando Paris):**  
+  - New repo to publish **system contract interfaces, validated wrappers, and hook reference implementations** for Hiero/Hedera EVM.  
+  - Distributed as an **NPM package** for standard Solidity workflows (Foundry/Hardhat).  
+  - **Not dependent** on OpenZeppelin by default; intent is to mimic its developer experience.  
+  - Scope excludes unrelated community contracts (example: LayerZero OTF code would remain elsewhere).  
+  - Outreach: plan to promote through LFDT/webinars and foundation channels.
+- **Proposal #2 — Hiero Ethereum Client Spec Tests repo (presented by Fernando Paris):**  
+  - Fork and adapt the **Ethereum execution-spec tests** (Python) to run against Hiero for **EVM-compat regression**.  
+  - Clearly mark/skip unsupported EIPs; some tests involve non-Solidity languages (e.g., Vyper) as part of the harness.
+- **Proposal #3 — Identity Collaboration Hub (presented by Keith Kowal & Diane Mueller):**  
+  - A central **hub repo** (modeled after SDK Collaboration Hub) for identity **architecture docs, standards work, non-SDK utilities/PoCs, documentation consolidation, and discussions**.  
+  - **Out of scope:** SDKs that publish artifacts (e.g., to NPM/PyPI) remain in dedicated repos.  
+  - Working guideline agreed in discussion: **no publishable artifacts** (e.g., NPM libraries) originate from this hub; if a code contribution matures, maintainers propose a separate repo via TSC.
+  - Existing “Hiero Identity Standards” repo to be **collapsed into the hub**.
+- **Proposal #4 — HOL HCS Specs repo (presented by Michael Kantor):**  
+  - Donate **Hashgraph Online HCS specifications** (application-layer patterns over HCS; e.g., **HCS-1** for on-chain file chunking/compression with ordered assembly) into a **Hiero repo**.  
+  - Specs governed by the existing HOL process (draft→publish) while living under Hiero.  
+  - **Naming** to be refined (acronym-heavy); preference for a clearer repo name.  
+  - **Alignment with HIPs:** consensus to create a **pointer HIP per HCS spec** (HIP file includes the canonical link/commit to the spec) rather than a single index HIP, improving visibility and version traceability.
+- **Voting/quorum:** No quorum today; items will proceed to **asynchronous vote** or a vote at the **next TSC meeting** after slide links are shared.
+
+---
+
+## Key Decisions
+
+- **Proceed with proposals to vote asynchronously or next meeting** due to lack of quorum.
+- **Identity Collaboration Hub guardrail:** Do **not** publish package artifacts from the hub repo; promote such work to separate repos when appropriate.
+- **HCS specs + HIP alignment:** Adopt a **per-spec pointer HIP** approach; the canonical spec remains in the donated repo, with HIPs providing reference, visibility, and version history.
+
+---
+
+## Action Items
+
+- **Hendrik Ebbers:** Start TSC channel thread with proposal links/recording; arrange **async vote** or schedule votes for the **Dec 2, 2025** meeting.  
+- **Fernando Paris:** Share slide deck links; prepare initial repo structures for Contracts and EVM Spec Tests.  
+- **Keith Kowal & Diane Mueller:** Update Identity Collaboration Hub docs to reflect artifact-publishing guardrail; share in identity working group.  
+- **Michael Kantor:** Update proposal (repo naming, pointer-HIP model) and share revised deck.  
+- **All TSC & community:** Review **HIP-1313** and comment.  
+- **Everyone interested:** Join the **Hiero Marketing** meeting (immediately after this call; see public calendar).
+
+---
+
+Prepared by: Brandon Davenport, Dir of Product, Hgraph


### PR DESCRIPTION
This PR adds the comprehensive minutes from the November 25, 2025 TSC meeting, including:
- Review of 4 project proposals: Hiero Contracts Repository, Hiero Ethereum Client Spec Tests, Identity Collaboration Hub, and HOL HCS Specs
- No quorum present; voting deferred to async ballot or next meeting
- Community asked to review HIP-1313
- Discussion on HIP alignment for HCS specs (pointer HIP per spec approach)