### PR TITLE
Add minutes for TSC meeting on 2025-12-02

### DIFF
--- a/minutes/2025-12-02.md
+++ b/minutes/2025-12-02.md
@@ -1,24 +1,110 @@
+# Hiero Technical Steering Committee Meeting
+
+**TL;DR:** TSC approved two new repositories (Hiero Contracts and Hiero Ethereum Client Spec) and approved the Identity Collaboration Hub (one abstention). Discussion on a separate “Hiero Consensus Specs” repo (donated HCS specs) continued; naming and governance alignment to be finalized next week. A new centralized governance wiki for meeting agendas/minutes was introduced.
+
+---
+
+## Details
+
+**Organization:** Hiero  
+**Date:** December 2, 2025  
+**Time:** 10:00 AM ET  
+**Recording:** https://zoom.us/rec/share/JE8Hzo9Wmcl9tVeoyj0S9qxRE5TtldcfrqIPpxFfgnNL74tI85-M9XmeYu9uG8ZW.cdFoNRq-Ul91ZdaL
+
+---
+
 ## TSC Attendees
+
+- Hendrik Ebbers
+- Richard Bair
+- Alexander Popowycz
+- Michael Kantor
+- Milan Wiercx van Rhijn
+- Brandon Davenport
+- Georgi Lazarov
 
 ## Guests
 
-As every Hiero meeting the TSC meeting is a public meeting and everybody can attend it.
-You can find all the information about the TSC meetings and all other Hiero meetings in our [public calender](https://zoom-lfx.platform.linuxfoundation.org/meetings/hiero?view=week).
+- Alexander Shenshin  
+- Andrew Brandt  
+- Angelina Ceppaluni  
+- Diane Mueller  
+- Jessica Gonzalez  
+- Joseph Sinclair  
+- Keith Kowal  
+- Mark Blackman  
+- Noah  
+- Pavel Borisov  
+- Priyanshu Yadav  
+- Roger Barker  
+- Jason Fabritz  
+- Michael Garber  
+- Najuna Brian  
+- Sophie Bulloch
+
+---
+
+## Agenda Items
+
+- Approve previous minutes  
+- Any updates/events from communities or members?  
+- HIPS ([Project board](https://github.com/orgs/hiero-ledger/projects/31/views/1?sortedBy%5Bdirection%5D=asc&sortedBy%5BcolumnId%5D=Status))  
+- Project proposals voting: [Hiero Contracts Repository](https://github.com/hiero-ledger/tsc/issues/248) and [Hiero Ethereum Client Spec](https://github.com/hiero-ledger/tsc/issues/249)  
+- Project proposals voting: [Identity Collaboration Hub](https://github.com/hiero-ledger/tsc/issues/263)  
+- Project proposals discussion: [hiero-hol-hcs-specs](https://github.com/hiero-ledger/tsc/issues/261)  
+- Wiki for Meetings and Minutes: https://github.com/hiero-ledger/governance/wiki  
+- Any other business (AOB)
+
+## Guests
+
+As every Hiero meeting the TSC meeting is a public meeting and everybody can attend it.  
+You can find all the information about the TSC meetings and all other Hiero meetings in our [public calender](https://zoom-lfx.platform.linuxfoundation.org/meetings/hiero).
 
 ## Code of Conduct
 
-As in every meeting we start with a short notice of the [antitrust policy of Linux Foundation](https://www.linuxfoundation.org/legal/antitrust-policy)
-and an introduction of our [Code of Conduct](https://www.lfdecentralizedtrust.org/code-of-conduct).
+As in every meeting we start with a short notice of the [antitrust policy of Linux Foundation](https://www.linuxfoundation.org/legal/antitrust-policy) and an introduction of our [Code of Conduct](https://www.lfdecentralizedtrust.org/code-of-conduct).
 
-<img width="945" alt="Code of Conduct" src="https://github.com/user-attachments/assets/3a187bc9-65ae-461e-bb46-7ce0db8e32cf">
+---
 
-## Agenda
+## Meeting Summary
 
-- Approve previous minutes
-- Any Updates/Events from Communities or members?
-- HIPs ([Project](https://github.com/orgs/hiero-ledger/projects/31/views/1?sortedBy%5Bdirection%5D=asc&sortedBy%5BcolumnId%5D=Status))
-- Project proposals voting: [Hiero Contracts Repository](https://github.com/hiero-ledger/tsc/issues/248) and [Hiero Ethereum Client Spec](https://github.com/hiero-ledger/tsc/issues/249)
-- Project proposals voting: [Identity Collaboration Hub](https://github.com/hiero-ledger/tsc/issues/263)
-- Project proposals voting: [hiero-hol-hcs-specs](https://github.com/hiero-ledger/tsc/issues/261)
-- Wiki for Meetings and Minutes: https://github.com/hiero-ledger/governance/wiki
-- Any other business (AOB)
+- **Community updates & events**
+  - LFDT **Maintainer Days (NYC)** and **LFDT Member Summit (NJ)** upcoming; maintainers and members encouraged to attend and coordinate a Hiero meetup.
+  - **Dec 10 virtual event:** “Patchwork / Longer Form Syncing on AI Standards” (cross-foundation standards collaboration).
+  - **FOSDEM (Brussels)**: Hendrik planning to attend and potentially present on Hiero; EU community members invited to coordinate.
+
+- **HIPS status**
+  - No urgent HIPS for TSC vote this week.  
+  - **HIP-1313** is the closest to coming forward; additional HIPS expected soon (e.g., cutover; block streams/nodes; node rewards) in the next few weeks.
+
+- **Project proposals (votes)**
+  1. **Hiero Contracts Repository** – *Approved* (unanimous among present TSC voters).  
+  2. **Hiero Ethereum Client Spec (ETH client test conformance fork)** – *Approved* (unanimous among present TSC voters).  
+  3. **Identity Collaboration Hub** – *Approved* (one abstention: Richard Bair; all other present TSC voters in favor).
+
+- **HCS specifications donation & repo structure (discussion continued)**
+  - Proposal for donating Hashgraph Online HCS specifications into Hiero under a dedicated repository.
+  - **Naming & neutrality:** General agreement that the repo name should be vendor-neutral (e.g., **“Hiero Consensus Specs”**). Avoid “HOL” branding in the repo name.
+  - **Process alignment:** Broad support for a **separate maintainer group** (not the TSC) to steward these specs; strong interest in:
+    - Maintaining continuity of existing HCS numbering/names (e.g., **HCS-1**).
+    - Establishing an **index HIP** in HIPS that ratifies/pointers to each published spec (each spec may also have a small companion file in HIPS for metadata/versioning and canonical commit SHA).
+  - **Open question:** Whether the specs repo should live **inside Hiero** or instead at **LFDT level** if stronger ledger-neutral positioning is required. Discussion to continue next week.
+
+- **Governance wiki for meetings/minutes**
+  - New **centralized wiki** in the governance repo for meeting agendas/minutes across Hiero communities was introduced.  
+  - TSC to consider moving TSC agendas/minutes into this wiki for consistency; fuller walkthrough planned for next meeting.
+
+---
+
+## Key Decisions
+
+- **APPROVED:** Hiero Contracts Repository.
+- **APPROVED:** Hiero Ethereum Client Spec repository.
+- **APPROVED:** Identity Collaboration Hub (**1 abstention** – Richard Bair).
+- **PENDING:** HCS specs donation/repo. Next steps:
+  - Michael Kantor to return with updated naming/governance proposal (e.g., “Hiero Consensus Specs”), including how HCS4 process maps to HIPS index ratification.
+  - TSC to revisit repo placement (Hiero vs. LFDT) and finalize approach next week.
+
+---
+
+Prepared by: Brandon Davenport, Dir of Product, Hgraph


### PR DESCRIPTION
**Description**:

This PR adds the comprehensive minutes from the December 2, 2025 TSC meeting.