### PR TITLE
Add minutes for TSC meeting on December 9, 2025

### DIFF
--- a/minutes/2025-12-09.md
+++ b/minutes/2025-12-09.md
@@ -1,16 +1,51 @@
+# Hiero Technical Steering Committee Meeting
+
+**TL;DR:** The TSC unanimously approved the project proposal to add **Hiero Consensus Specifications** (`hiero-consensus-specifications`) under the Hiero organization. The group also reviewed the new governance wiki for meeting minutes, agreed to move TSC minutes there, and aligned on creating a TSC email alias/mailing list for easier community outreach.
+
+---
+
+## Details
+
+**Organization:** Hiero  
+**Date:** Tuesday, December 9, 2025  
+**Time:** 10:00 AM ET  
+**Recording:** https://zoom.us/rec/share/Yhnl8WINrWp9fYd9Vr-zh9pZ-8em-3BoHfByT5lx5428IBseT10BQ_FiNtrBhjGV.JbZHy5VAkHNLZ5gK
+
+---
+
 ## TSC Attendees
+
+- Brandon Davenport
+- Hendrik Ebbers
+- Michael Kantor
+- Georgi Lazarov
+- Richard Bair
+- Milan Wiercx van Rhijn
+- Stoyan Panayotov
+- Alexander Popowycz
 
 ## Guests
 
-As every Hiero meeting the TSC meeting is a public meeting and everybody can attend it.
-You can find all the information about the TSC meetings and all other Hiero meetings in our [public calender](https://zoom-lfx.platform.linuxfoundation.org/meetings/hiero?view=week).
+- Andrew Brandt
+- Angelina Ceppaluni
+- Diane Mueller
+- Jessica Gonzalez
+- Joseph Sinclair
+- Keith Kowal
+- Kiran Pachhai
+- Mark Blackman
+- Noah
+- Pavel Borisov
+- Priyanshu Yadav
+- Roger Barker
+- Jason Fabritz
+- Michael Garber
+- Najuna Brian
+- Sophie Bulloch
+- Manuel Wandres
+- Ian Sparkes
 
-## Code of Conduct
-
-As in every meeting we start with a short notice of the [antitrust policy of Linux Foundation](https://www.linuxfoundation.org/legal/antitrust-policy)
-and an introduction of our [Code of Conduct](https://www.lfdecentralizedtrust.org/code-of-conduct).
-
-<img width="945" alt="Code of Conduct" src="https://github.com/user-attachments/assets/3a187bc9-65ae-461e-bb46-7ce0db8e32cf">
+---
 
 ## Agenda
 
@@ -21,3 +56,61 @@ and an introduction of our [Code of Conduct](https://www.lfdecentralizedtrust.or
 - Wiki for Meetings and Minutes: https://github.com/hiero-ledger/governance/wiki
 - Request to create a TSC mailing list as easy way to contact all TSC members
 - Any other business (AOB)
+
+## Guests
+
+As every Hiero meeting the TSC meeting is a public meeting and everybody can attend it.  
+You can find all the information about the TSC meetings and all other Hiero meetings in our [public calender](https://zoom-lfx.platform.linuxfoundation.org/meetings/hiero).
+
+## Code of Conduct
+
+As in every meeting we start with a short notice of the [antitrust policy of Linux Foundation](https://www.linuxfoundation.org/legal/antitrust-policy) and an introduction of our [Code of Conduct](https://www.lfdecentralizedtrust.org/code-of-conduct).
+
+---
+
+## Meeting Summary
+
+- **Moderation / roll-in:** Brandon Davenport moderated because Hendrik Ebbers was initially unavailable; Hendrik later joined and asked for a recap.
+- **Previous minutes:** Brandon noted **three open PRs** in the TSC repo for prior minutes that still need additional approving reviews before merging.
+- **Community updates / events:**
+  - Michael Kantor reminded attendees about **“Patchwork: Syncing on AI Standards”** (Dec 10) and shared that the event includes participation from groups such as IEEE and Linux Foundation (link was shared in chat; it is also listed on the governance wiki).
+- **Good first issue enablement (Sophie Bulloch):**
+  - Sophie shared progress on **“good first issue” templates** (currently used in the Python SDK) that pre-fill structure, onboarding steps, and labeling to make it faster and more consistent to create beginner-friendly issues.
+  - Sophie indicated work is in progress to extend similar templates across other Hiero repositories.
+- **HIPs dashboard:**
+  - Brandon called out **HIP-1208** as “in review” and asked for any updates.
+  - Mark Blackman flagged **records-to-block-streams cutover** work as a near-term focus, noting it will go through a rewrite and may surface in upcoming meetings.
+- **Project proposal vote (HCS / consensus specs):**
+  - Michael reported the Hashgraph Online DAO aligned on the updated name: **Hiero Consensus Specifications** (keeps the “HCS” acronym continuity).
+  - The TSC confirmed quorum was sufficient for a vote (per Richard Bair: “We have 6…”).
+  - The TSC **unanimously approved** the project proposal to create `hiero-consensus-specifications` under the Hiero organization.
+- **Meetings & minutes wiki (Jessica Gonzalez):**
+  - Jessica walked through the governance wiki, including instructions for adding meeting entries, upcoming announcements, and the schedule/registration links table.
+  - Key operational note: the wiki is **editable directly** (no PR required), with a reminder to edit carefully.
+  - Discussion clarified why TSC minutes historically used PR approvals (to keep an auditable record of approval) and proposed an alternative: approve minutes verbally at the start of the next meeting (e.g., “any objections” / “two people approve”).
+  - Brandon and Hendrik aligned to **move TSC agendas/minutes into the wiki** going forward.
+- **TSC mailing list / contact alias:**
+  - Hendrik proposed creating a simple **email alias** (not for internal long threads) so community members and LF staff can email *one address* and reach all TSC members.
+  - Jessica confirmed LF can implement this (via groups.io) and asked TSC members to send their preferred email addresses to Hendrik (or to Jessica via Hendrik).
+
+---
+
+## Key Decisions
+
+1. **Approved:** Project Proposal to create **`hiero-consensus-specifications`** (Hiero Consensus Specifications) under Hiero.
+2. **Agreed (process change):** Transition TSC agendas/minutes to the **governance wiki**, with approval handled during meetings rather than PR-based approvals (details to be implemented by the minute-takers and LF support).
+3. **Agreed (direction):** Create a **TSC email alias/mailing list** to simplify contacting all TSC members.
+
+---
+
+## Action Items
+
+- **All TSC members:** Provide the remaining approving reviews needed to merge the **three** outstanding “previous minutes” PRs (async).
+- **Michael Kantor:** Email `ecosystem@lfdecentralizedtrust.org` and CC Jessica Gonzalez to complete registration for LF events (Maintainer Days / Member Summit) per Jessica’s guidance.
+- **All TSC members:** Send preferred contact email addresses to **Hendrik Ebbers** (who will forward to Jessica) so LF can create the **TSC mailing list / alias**.
+- **Brandon Davenport (with Jessica support):** Begin transitioning TSC minutes/agendas into the governance wiki workflow.
+- **Sophie Bulloch / Hendrik Ebbers / Jessica Gonzalez:** Continue the discussion on where analytics/reporting code should live (governance repo vs separate repo), and raise it in the upcoming TAG context as discussed.
+
+---
+
+Prepared by: Brandon Davenport, Dir of Product, Hgraph


### PR DESCRIPTION
**Description**:

This PR adds the minutes from the December 9, 2025 TSC meeting, including:
- Unanimous approval of the Hiero Consensus Specifications project proposal
- Agreement to transition TSC agendas/minutes to the governance wiki
- Agreement to create a TSC email alias/mailing list
- Action items for TSC members