### PR TITLE
Add minutes for TSC meeting on December 16, 2025

### DIFF
--- a/minutes/2025-12-16.md
+++ b/minutes/2025-12-16.md
@@ -1,18 +1,44 @@
+# Hiero Technical Steering Committee Meeting
+
+**TL;DR:** The TSC voted to move agendas/minutes to the `hiero-ledger/governance` GitHub Wiki starting with the first 2026 meeting, and the Linux Foundation began setting up a TSC mailing list (test emails sent). No new HIPs were presented; the group also discussed expanding “Good First Issue” support beyond the Python SDK.
+
+---
+
+## Details
+
+**Organization:** Hiero  
+**Date:** December 16, 2025  
+**Time:** 10:00am ET  
+**Recording:** https://zoom.us/rec/share/9nKXiI6Nv44EihzfIqil_onYAj7I51GZybUYJ5OJc8cHbrBGSGoeM8qe3NOpqWPG.1PHP_L6SN9Jgmvi6
+
+---
+
 ## TSC Attendees
+
+- Brandon Davenport
+- Hendrik Ebbers
+- Alex Popowycz
+- Georgi Lazarov
+- Michael Kantor
+- Milan Wiercx van Rhijn
+- Stoyan Panayotov
 
 ## Guests
 
-As every Hiero meeting the TSC meeting is a public meeting and everybody can attend it.
-You can find all the information about the TSC meetings and all other Hiero meetings in our [public calender](https://zoom-lfx.platform.linuxfoundation.org/meetings/hiero?view=week).
+- Alexander Shenshin
+- Andrew Brandt
+- Angelina Ceppaluni
+- Diane Mueller
+- Jessica Gonzalez
+- Joseph Sinclair
+- Mark Blackman
+- Robert Walworth
+- Roger Barker
+- Sophie Bulloch
 
-## Code of Conduct
+---
 
-As in every meeting we start with a short notice of the [antitrust policy of Linux Foundation](https://www.linuxfoundation.org/legal/antitrust-policy)
-and an introduction of our [Code of Conduct](https://www.lfdecentralizedtrust.org/code-of-conduct).
-
-<img width="945" alt="Code of Conduct" src="https://github.com/user-attachments/assets/3a187bc9-65ae-461e-bb46-7ce0db8e32cf">
-
-## Agenda
+## Agenda Items
 
 - Approve previous minutes
 - Any Updates/Events from Communities or members?
@@ -21,3 +47,43 @@ and an introduction of our [Code of Conduct](https://www.lfdecentralizedtrust.or
 - Update: Request to create a TSC mailing list as easy way to contact all TSC members
 - Good First Issue SDK Committee
 - Any other business (AOB)
+
+## Guests
+
+As every Hiero meeting the TSC meeting is a public meeting and everybody can attend it.  
+You can find all the information about the TSC meetings and all other Hiero meetings in our [public calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/hiero?view=week).
+
+## Code of Conduct
+
+As in every meeting we start with a short notice of the [antitrust policy of Linux Foundation](https://www.linuxfoundation.org/legal/antitrust-policy) and an introduction of our [Code of Conduct](https://www.lfdecentralizedtrust.org/code-of-conduct).
+
+---
+
+## Meeting Summary
+
+- **Holiday scheduling:** The group agreed to **cancel the December 23, 2025** meeting due to the holidays (with a lighthearted note that anyone who would have joined “deserves a t-shirt”).
+- **Previous minutes:** Hendrik noted there are outstanding minutes that still need to be merged; he planned to review them immediately after this meeting.
+- **Community updates:** No specific community updates were raised during the update round.
+- **HIPs:** Mark shared there were **no new HIPs to present** this week. He noted a “bulk” of HIPs may come through early next year, and referenced **HIP-1313** as a likely near-term item (timing dependent on its driver).
+- **Agenda/minutes location (Wiki):** The TSC held a formal vote to move TSC agendas and minutes to the **GitHub Wiki** under `hiero-ledger/governance`.
+  - Discussion included whether to migrate historical minutes or only move forward.
+  - The agreed approach was to **start the Wiki workflow with the first 2026 meeting**, and add cross-references so people can find prior meeting history.
+- **TSC mailing list:** Jessica provided a status update on establishing a **TSC mailing list** for urgent/out-of-band contact with TSC members.
+  - She planned to send **test emails** and asked members to reply to confirm correct addresses.
+  - Richard’s address was noted as needing profile/support-team updates to align with the confirmed address.
+- **Good First Issue support (SDKs):** Sophie shared progress on a proposal to scale the “Good First Issue” approach (successful in the Python SDK) to other SDKs.
+  - She described the effort required to create and support high-quality starter issues (templates, responsiveness, troubleshooting DCO/signing, quick reviews, etc.).
+  - Current working concept: a **“Good First Issue support team”** (opt-in), to provide broader coverage and faster turnaround for contributors.
+  - Community members were encouraged to join the relevant community calls to participate in the ongoing discussion.
+
+---
+
+## Key Decisions
+
+- **Approved (vote):** Move TSC agendas and minutes to the `hiero-ledger/governance` **GitHub Wiki**, with the **new workflow starting at the first meeting in 2026**.
+- **Approved (agreement):** **Cancel the December 23, 2025** meeting due to holidays.
+- **Proceed (operational):** Linux Foundation to continue standing up the **TSC mailing list** and run test emails to confirm delivery and addresses.
+
+---
+
+Prepared by: Brandon Davenport


### PR DESCRIPTION
This PR adds the minutes from the December 16, 2025 TSC meeting.